### PR TITLE
Support postalCodes parameter on sr_search_form

### DIFF
--- a/simply-rets-post-pages.php
+++ b/simply-rets-post-pages.php
@@ -677,11 +677,15 @@ class SimplyRetsCustomPostPages {
                 }
             }
 
+            /** Parse multiple postalCodes from short-code parameter */
             $postalCodes = isset($_GET['sr_postalCodes']) ? $_GET['sr_postalCodes'] : '';
             $postalCodes_string = "";
-            if(!empty($postalCodes)) {
-                foreach((array)$postalCodes as $key => $postalCode) {
-                    $postalCodes_string .= "&postalCodes=$postalCode";
+            $postalCodes_arr = is_array($postalCodes) ? $postalCodes : explode(";", $postalCodes);
+
+            if(is_array($postalCodes_arr) && !empty($postalCodes_arr)) {
+                foreach((array)$postalCodes_arr as $key => $zip) {
+                    $final = trim($zip);
+                    $postalCodes_string .= "&postalCodes=$zip";
                 }
             }
 
@@ -786,7 +790,8 @@ class SimplyRetsCustomPostPages {
                 "q" => $kw_string,
                 "agent" => get_query_var('sr_agent', ''),
                 "status" => $statuses_attribute,
-                "advanced" => $advanced == "true" ? "true" : "false"
+                "advanced" => $advanced == "true" ? "true" : "false",
+                "postalCodes" => $postalCodes
             );
 
             // Create a string of attributes to put on the

--- a/simply-rets-shortcode.php
+++ b/simply-rets-shortcode.php
@@ -395,6 +395,7 @@ HTML;
         $limit   = isset($atts['limit'])   ? $atts['limit']   : '';
         $config_type = isset($atts['type']) ? $atts['type']   : '';
         $counties = isset($atts['counties']) ? $atts['counties'] : '';
+        $postalCodes = isset($atts['postalcodes']) ? $atts['postalcodes'] : '';
 
         if($config_type === '') {
             $config_type = isset($_GET['sr_ptype']) ? $_GET['sr_ptype'] : '';
@@ -641,6 +642,7 @@ HTML;
                 <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
                 <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
                 <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
+                <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
 
 
                 <div>
@@ -727,6 +729,7 @@ HTML;
             <input type="hidden" name="sr_brokers" value="<?php echo $brokers; ?>" />
             <input type="hidden" name="sr_agent"   value="<?php echo $agent; ?>" />
             <input type="hidden" name="sr_counties" value="<?php echo $counties; ?>" />
+            <input type="hidden" name="sr_postalCodes" value="<?php echo $postalCodes; ?>" />
             <input type="hidden" name="limit"      value="<?php echo $limit; ?>" />
             <input type="hidden" name="status"     value="<?php echo $adv_status; ?>" />
 


### PR DESCRIPTION
This allows the user to restrict the [sr_search_form] short-code with
specific postalCode attributes. Not all attributes are supported on
the search form, but this adds support for postalCodes to be used this
way.

Example:

[sr_search_form postalCodes="12345; 67890"]