### PR TITLE
Fix [sr_listings_slider] layout with less than 4 listings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.6
+
+* FIX: Fix [sr_listings_slider] layout when there are < 4 listings
+
 ## 3.2.5
 
 * FIX: Handle corner cases in data handling

--- a/src/assets/js/simply-rets-client.js
+++ b/src/assets/js/simply-rets-client.js
@@ -74,11 +74,23 @@ var advSearchFormToggler = function () {
 var listingSliderCarousel = function () {
 
     $_(".owl-carousel").each(function () {
-        $_(this).owlCarousel({
+        var $carousel = $_(this);
+        var itemCount = $carousel.children().length;
+
+        $carousel.owlCarousel({
             items: 4,
-            loop: true,
+            // Only enable infinite loop if there are more items than the viewport holds
+            loop: itemCount > 4,
             nav: true,
-            slideBy: 4
+            slideBy: 4,
+            onInitialized: function (event) {
+                // If there are fewer than 4 items, center the internal stage wrapper
+                if (itemCount < 4) {
+                    $_(event.target).find('.owl-stage').css({
+                        'margin': '0 auto'
+                    });
+                }
+            }
         })
     });
 

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: real estate, idx, mls, rets, reso web api
 Requires at least: 3.0.1
 Tested up to: 6.9
-Stable tag: 3.2.5
+Stable tag: 3.2.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 3.2.6 =
+
+* FIX: Fix [sr_listings_slider] layout when there are < 4 listings
 
 = 3.2.5 =
 

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS Real Estate IDX
 Plugin URI: https://simplyrets.com/wordpress-idx-plugin
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 3.2.5
+Version: 3.2.6
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2026
@@ -15,7 +15,7 @@ if (! defined('ABSPATH')) {
 }
 
 /* Code starts here */
-const SIMPLYRETSWP_VERSION = "v3.2.5";
+const SIMPLYRETSWP_VERSION = "v3.2.6";
 
 $plugin = plugin_basename(__FILE__);
 $php_version = phpversion();


### PR DESCRIPTION
Fix the layout of `[sr_listings_slider]` when there are less than 4 listings matching the filters.

Don't use owl-carousel loop with less than 4 listings
Center carousel items when there are less than 4 listings