### PR TITLE
Pin googlemaps js version to support DrawingManager

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.7
+
+* FIX: Pin GoogleMaps JS version to support DrawingManager
+
 ## 3.2.6
 
 * FIX: Fix [sr_listings_slider] layout when there are < 4 listings

--- a/src/assets/js/simply-rets-client.js
+++ b/src/assets/js/simply-rets-client.js
@@ -913,7 +913,8 @@ $_(document).ready(function () {
 
             // if google.maps doesn't exist - load it, then start map
             var url = "https://maps.googleapis.com/maps/api/js?"
-                + "libraries=drawing&callback=startMap"
+                + "v=3.64" // Pin version to support DrawingManager
+                + "&libraries=drawing&callback=startMap"
                 + "&key=" + key;
 
             var script = document.createElement("script");

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -4,7 +4,7 @@ Contributors: SimplyRETS
 Tags: real estate, idx, mls, rets, reso web api
 Requires at least: 3.0.1
 Tested up to: 6.9
-Stable tag: 3.2.6
+Stable tag: 3.2.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -234,6 +234,10 @@ listing sidebar widget.
 
 
 == Changelog ==
+
+= 3.2.7 =
+
+* FIX: Pin GoogleMaps JS version to support DrawingManager
 
 = 3.2.6 =
 

--- a/src/simply-rets.php
+++ b/src/simply-rets.php
@@ -4,7 +4,7 @@ Plugin Name: SimplyRETS Real Estate IDX
 Plugin URI: https://simplyrets.com/wordpress-idx-plugin
 Description: Show your Real Estate listings on your Wordpress site. SimplyRETS provides a very simple set up and full control over your listings.
 Author: SimplyRETS
-Version: 3.2.6
+Version: 3.2.7
 License: GNU General Public License v3 or later
 
 Copyright (c) SimplyRETS 2014 - 2026
@@ -15,7 +15,7 @@ if (! defined('ABSPATH')) {
 }
 
 /* Code starts here */
-const SIMPLYRETSWP_VERSION = "v3.2.6";
+const SIMPLYRETSWP_VERSION = "v3.2.7";
 
 $plugin = plugin_basename(__FILE__);
 $php_version = phpversion();


### PR DESCRIPTION
Pin the version of google maps we load for the `[sr_map_search]` shortcode to support `DrawingManager` functionality.

DrawingManager was deprecated in GoogleMaps v3.65, so this pins the library to version v3.64.